### PR TITLE
Lesson 08: Raw RSocket sub-project (Bidirectional, Metadata)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ Each module is implemented in both [Java](./java) and [Kotlin](./kotlin) to comp
 - Implemented parallel Kotlin versions of Java examples
 - Updated to Spring Boot 3.5.x while the book uses an older Spring Boot version 2.5.0
 - Adopted a monorepo approach with [Gradle Multi-project Builds][gradle-multiproject] and [Gradle Composite Builds][gradle-composite-builds] to manage both Java and Kotlin implementations in a single repository
+    - Learned that Gradle Kotlin DSL supports both type-safe and string-based dependency declarations, and that the string-based form was required
+        in [`08:rsocket/build.gradle.kts`](./kotlin/08-rsocket/build.gradle.kts) when adding dependencies inside `afterEvaluate`
+    - Learned that some plugins (e.g., `spring-boot`, `dependency-management`) must be applied with `apply(false)` in the root and then enabled in subprojects, since they cannot be declared directly like `kotlin("jvm")`.
 - Implemented database profile switching between R2DBC, MongoDB, and other providers
 - Implemented reactive global error handling in [`ExceptionProblemResponseMapper#map`](https://github.com/fResult/Learn-Spring-Webflux-3.0/blob/72805b595fe7e3b692d7ccce6d78d2611b40abd3/kotlin/07-http/webflux/src/main/kotlin/com/fResult/common/ExceptionProblemResponseMapper.kt#L13-L21)
     (utilized in [`ErrorHandlingRouteConfiguration`](https://github.com/fResult/Learn-Spring-Webflux-3.0/blob/72805b5/kotlin/07-http/webflux/src/main/kotlin/com/fResult/http/filters/ErrorHandlingRouteConfiguration.kt#L18) class).

--- a/kotlin/08-rsocket/build.gradle.kts
+++ b/kotlin/08-rsocket/build.gradle.kts
@@ -34,6 +34,7 @@ subprojects {
   afterEvaluate {
     dependencies {
       "implementation"(libs.spring.boot.starter.rsocket)
+      "implementation"("com.fasterxml.jackson.module:jackson-module-kotlin")
       "implementation"("io.projectreactor.kotlin:reactor-kotlin-extensions")
       "implementation"("org.jetbrains.kotlin:kotlin-reflect")
       "implementation"("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")

--- a/kotlin/08-rsocket/common/src/main/kotlin/com/fResult/rsocket/EncodingUtils.kt
+++ b/kotlin/08-rsocket/common/src/main/kotlin/com/fResult/rsocket/EncodingUtils.kt
@@ -11,8 +11,8 @@ class EncodingUtils(private val objectMapper: ObjectMapper) {
     private val logger = LogManager.getLogger()
   }
 
-  private val objectReader = objectMapper.readerFor(Any::class.java)
   private val typeReference = typeRef<Map<String, Any>>()
+  private val objectReader = objectMapper.readerFor(typeReference)
 
   fun <T : Any> decode(json: String, klass: KClass<T>): T =
     runCatching { objectMapper.readValue(json, klass.java) }
@@ -35,6 +35,7 @@ class EncodingUtils(private val objectMapper: ObjectMapper) {
             logger.error("Failed to encode object of type ${obj::class.simpleName}", ex)
             throw EncodingException("Unable to encode ${obj::class.simpleName}", ex)
           }
+
           else -> throw ex
         }
       }

--- a/kotlin/08-rsocket/common/src/main/kotlin/com/fResult/rsocket/FResultAutoConfiguration.kt
+++ b/kotlin/08-rsocket/common/src/main/kotlin/com/fResult/rsocket/FResultAutoConfiguration.kt
@@ -10,7 +10,4 @@ import org.springframework.context.annotation.Configuration
 class FResultAutoConfiguration {
   @Bean
   fun encodingUtils(objectMapper: ObjectMapper) = EncodingUtils(objectMapper)
-
-  @Bean
-  fun objectMapper() = ObjectMapper()
 }

--- a/kotlin/08-rsocket/common/src/main/kotlin/com/fResult/rsocket/dsl/retry/RetryConfig.kt
+++ b/kotlin/08-rsocket/common/src/main/kotlin/com/fResult/rsocket/dsl/retry/RetryConfig.kt
@@ -1,0 +1,9 @@
+package com.fResult.rsocket.dsl.retry
+
+import java.time.Duration
+
+data class RetryConfig(
+  val maxAttempts: Long,
+  val firstBackOff: Duration,
+  val maxBackoff: Duration,
+)

--- a/kotlin/08-rsocket/common/src/main/kotlin/com/fResult/rsocket/dsl/retry/RetryConfigBuilder.kt
+++ b/kotlin/08-rsocket/common/src/main/kotlin/com/fResult/rsocket/dsl/retry/RetryConfigBuilder.kt
@@ -1,0 +1,17 @@
+package com.fResult.rsocket.dsl.retry
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toJavaDuration
+
+class RetryConfigBuilder {
+  var maxAttempts: Int = 5
+  var firstBackOff: Duration = 1.seconds
+  var maxBackoff: Duration = 32.seconds
+
+  fun build() = RetryConfig(
+    maxAttempts = maxAttempts.toLong(),
+    firstBackOff = firstBackOff.toJavaDuration(),
+    maxBackoff = maxBackoff.toJavaDuration(),
+  )
+}

--- a/kotlin/08-rsocket/raw-rsocket/build.gradle.kts
+++ b/kotlin/08-rsocket/raw-rsocket/build.gradle.kts
@@ -54,3 +54,20 @@ tasks.register<BootRun>("bootChannelClient") {
   mainClass = "com.fResult.rsocket.channel.client.ChannelApplicationKt"
   classpath = sourceSets["main"].runtimeClasspath
 }
+
+/* ==================================== *
+ * ========= Bidirectional ============ *
+ * ==================================== */
+tasks.register<BootRun>("bootBidirectionalService") {
+  group = "application"
+  description = "Run the RSocket Bidirectional Server"
+  mainClass = "com.fResult.rsocket.bidirectional.service.BidirectionalApplicationKt"
+  classpath = sourceSets["main"].runtimeClasspath
+}
+
+tasks.register<BootRun>("bootBidirectionalClient") {
+  group = "application"
+  description = "Run the RSocket Bidirectional Client"
+  mainClass = "com.fResult.rsocket.bidirectional.client.BidirectionalApplicationKt"
+  classpath = sourceSets["main"].runtimeClasspath
+}

--- a/kotlin/08-rsocket/raw-rsocket/build.gradle.kts
+++ b/kotlin/08-rsocket/raw-rsocket/build.gradle.kts
@@ -2,6 +2,9 @@ import org.springframework.boot.gradle.tasks.run.BootRun
 
 dependencies {
   implementation(project(":common"))
+
+  // MacOS ARM (Apple Silicon) DNS resolver
+  runtimeOnly("io.netty:netty-resolver-dns-native-macos:4.1.89.Final:osx-aarch_64")
 }
 
 /* ================================ *

--- a/kotlin/08-rsocket/raw-rsocket/src/main/kotlin/com/fResult/rsocket/bidirectional/ClientHealthState.kt
+++ b/kotlin/08-rsocket/raw-rsocket/src/main/kotlin/com/fResult/rsocket/bidirectional/ClientHealthState.kt
@@ -1,0 +1,8 @@
+package com.fResult.rsocket.bidirectional
+
+class ClientHealthState(val state: String) {
+  companion object {
+    const val STARTED = "started"
+    const val STOPPED = "stopped"
+  }
+}

--- a/kotlin/08-rsocket/raw-rsocket/src/main/kotlin/com/fResult/rsocket/bidirectional/GreetingRequest.kt
+++ b/kotlin/08-rsocket/raw-rsocket/src/main/kotlin/com/fResult/rsocket/bidirectional/GreetingRequest.kt
@@ -1,0 +1,3 @@
+package com.fResult.rsocket.bidirectional
+
+data class GreetingRequest(val message: String)

--- a/kotlin/08-rsocket/raw-rsocket/src/main/kotlin/com/fResult/rsocket/bidirectional/GreetingRequest.kt
+++ b/kotlin/08-rsocket/raw-rsocket/src/main/kotlin/com/fResult/rsocket/bidirectional/GreetingRequest.kt
@@ -1,3 +1,3 @@
 package com.fResult.rsocket.bidirectional
 
-data class GreetingRequest(val message: String)
+data class GreetingRequest(val name: String)

--- a/kotlin/08-rsocket/raw-rsocket/src/main/kotlin/com/fResult/rsocket/bidirectional/GreetingResponse.kt
+++ b/kotlin/08-rsocket/raw-rsocket/src/main/kotlin/com/fResult/rsocket/bidirectional/GreetingResponse.kt
@@ -1,4 +1,3 @@
 package com.fResult.rsocket.bidirectional
 
 data class GreetingResponse(val message: String)
-

--- a/kotlin/08-rsocket/raw-rsocket/src/main/kotlin/com/fResult/rsocket/bidirectional/GreetingResponse.kt
+++ b/kotlin/08-rsocket/raw-rsocket/src/main/kotlin/com/fResult/rsocket/bidirectional/GreetingResponse.kt
@@ -1,0 +1,4 @@
+package com.fResult.rsocket.bidirectional
+
+data class GreetingResponse(val message: String)
+

--- a/kotlin/08-rsocket/raw-rsocket/src/main/kotlin/com/fResult/rsocket/bidirectional/client/BidirectionalApplication.kt
+++ b/kotlin/08-rsocket/raw-rsocket/src/main/kotlin/com/fResult/rsocket/bidirectional/client/BidirectionalApplication.kt
@@ -1,0 +1,13 @@
+package com.fResult.rsocket.bidirectional.client
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+@SpringBootApplication
+class BidirectionalApplication
+
+@Throws(InterruptedException::class)
+fun main(args: Array<String>) {
+  runApplication<BidirectionalApplication>(*args)
+  Thread.currentThread().join()
+}

--- a/kotlin/08-rsocket/raw-rsocket/src/main/kotlin/com/fResult/rsocket/bidirectional/client/BidirectionalClient.kt
+++ b/kotlin/08-rsocket/raw-rsocket/src/main/kotlin/com/fResult/rsocket/bidirectional/client/BidirectionalClient.kt
@@ -1,0 +1,72 @@
+package com.fResult.rsocket.bidirectional.client
+
+import com.fResult.rsocket.EncodingUtils
+import com.fResult.rsocket.bidirectional.ClientHealthState
+import com.fResult.rsocket.bidirectional.GreetingRequest
+import com.fResult.rsocket.bidirectional.GreetingResponse
+import io.rsocket.ConnectionSetupPayload
+import io.rsocket.Payload
+import io.rsocket.RSocket
+import io.rsocket.core.RSocketConnector
+import io.rsocket.transport.netty.client.TcpClientTransport
+import io.rsocket.transport.netty.server.CloseableChannel
+import io.rsocket.util.DefaultPayload
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import java.time.Instant
+import java.util.stream.Stream
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toJavaDuration
+
+class BidirectionalClient(
+  private val encodingUtils: EncodingUtils,
+  private val uid: String,
+  private val serviceHostname: String,
+  private val servicePort: Int,
+) {
+  companion object {
+    val log: Logger = LogManager.getLogger(BidirectionalClient::class.java)
+  }
+
+  fun getGreetings(): Flux<GreetingResponse?> {
+    val greetingRequestPayload = encodingUtils.encode(GreetingRequest("Client #$uid"))
+
+    return RSocketConnector.create()
+      .acceptor(::acceptor)
+      .connect(TcpClientTransport.create(serviceHostname, servicePort))
+      .flatMapMany { socket ->
+        socket.requestStream(DefaultPayload.create(greetingRequestPayload))
+          .map { payload -> encodingUtils.decode(payload.dataUtf8, GreetingResponse::class) }
+      }
+  }
+
+  private fun acceptor(setup: ConnectionSetupPayload, serverRSocket: RSocket): Mono<RSocket> =
+    Mono.just(createRequestStreamHandler())
+
+  private fun createRequestStreamHandler(): RSocket =
+    object : RSocket {
+      override fun requestStream(payload: Payload): Flux<Payload> {
+        val start = Instant.now().toEpochMilli()
+        val delayMillis = (0..30_000).random().toLong()
+
+        val stateFlux = Flux.fromStream(Stream.generate {
+          val now = Instant.now().toEpochMilli()
+          val stop = ((start + delayMillis) < now) && Math.random() > .8
+
+          ClientHealthState(if (stop) "STOPPED" else "STARTED")
+        })
+          .delayElements(5.seconds.toJavaDuration())
+
+        return stateFlux
+          .map(encodingUtils::encode)
+          .map(DefaultPayload::create)
+      }
+
+
+      private fun logStartup(channel: CloseableChannel) {
+        log.info("Server started on the address: {}", channel.address())
+      }
+    }
+}

--- a/kotlin/08-rsocket/raw-rsocket/src/main/kotlin/com/fResult/rsocket/bidirectional/client/BidirectionalClient.kt
+++ b/kotlin/08-rsocket/raw-rsocket/src/main/kotlin/com/fResult/rsocket/bidirectional/client/BidirectionalClient.kt
@@ -38,7 +38,7 @@ class BidirectionalClient(
       .flatMapMany { socket ->
         socket.requestStream(DefaultPayload.create(greetingRequestPayload))
           .doOnNext(::logReceivedResponse)
-          .map { payload -> encodingUtils.decode(payload.dataUtf8, GreetingResponse::class) }
+          .map(::toGreetingResponse)
       }
   }
 
@@ -68,4 +68,7 @@ class BidirectionalClient(
   fun logReceivedResponse(payload: Payload) {
     log.info("Received response data: {}", payload.dataUtf8)
   }
+
+  fun toGreetingResponse(payload: Payload): GreetingResponse =
+    encodingUtils.decode(payload.dataUtf8, GreetingResponse::class)
 }

--- a/kotlin/08-rsocket/raw-rsocket/src/main/kotlin/com/fResult/rsocket/bidirectional/client/BidirectionalClient.kt
+++ b/kotlin/08-rsocket/raw-rsocket/src/main/kotlin/com/fResult/rsocket/bidirectional/client/BidirectionalClient.kt
@@ -9,7 +9,6 @@ import io.rsocket.Payload
 import io.rsocket.RSocket
 import io.rsocket.core.RSocketConnector
 import io.rsocket.transport.netty.client.TcpClientTransport
-import io.rsocket.transport.netty.server.CloseableChannel
 import io.rsocket.util.DefaultPayload
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
@@ -38,6 +37,7 @@ class BidirectionalClient(
       .connect(TcpClientTransport.create(serviceHostname, servicePort))
       .flatMapMany { socket ->
         socket.requestStream(DefaultPayload.create(greetingRequestPayload))
+          .doOnNext(::logReceivedResponse)
           .map { payload -> encodingUtils.decode(payload.dataUtf8, GreetingResponse::class) }
       }
   }
@@ -63,10 +63,9 @@ class BidirectionalClient(
           .map(encodingUtils::encode)
           .map(DefaultPayload::create)
       }
-
-
-      private fun logStartup(channel: CloseableChannel) {
-        log.info("Server started on the address: {}", channel.address())
-      }
     }
+
+  fun logReceivedResponse(payload: Payload) {
+    log.info("Received response data: {}", payload.dataUtf8)
+  }
 }

--- a/kotlin/08-rsocket/raw-rsocket/src/main/kotlin/com/fResult/rsocket/bidirectional/client/BidirectionalClientLauncher.kt
+++ b/kotlin/08-rsocket/raw-rsocket/src/main/kotlin/com/fResult/rsocket/bidirectional/client/BidirectionalClientLauncher.kt
@@ -31,7 +31,7 @@ class BidirectionalClientLauncher(
 
     Flux.fromStream(IntStream.range(0, maxClients).boxed())
       .map(buildBidirectionalClient(encodingUtils, hostname, port))
-      .flatMap { client -> Flux.just(client).delayElements((1..30).random().seconds.toJavaDuration()) }
+      .flatMap(::toDelayClient)
       .flatMap(BidirectionalClient::getGreetings)
       .subscribe(::logGreetingResponse)
   }
@@ -43,6 +43,9 @@ class BidirectionalClientLauncher(
   ): (Int) -> BidirectionalClient = { id ->
     BidirectionalClient(encodingUtils, id.toString(), host, port)
   }
+
+  fun toDelayClient(client: BidirectionalClient): Flux<BidirectionalClient> =
+    Flux.just(client).delayElements((1..30).random().seconds.toJavaDuration())
 
   private fun logGreetingResponse(greeting: GreetingResponse?): Unit {
     greeting?.apply { log.info(message) }

--- a/kotlin/08-rsocket/raw-rsocket/src/main/kotlin/com/fResult/rsocket/bidirectional/client/BidirectionalClientLauncher.kt
+++ b/kotlin/08-rsocket/raw-rsocket/src/main/kotlin/com/fResult/rsocket/bidirectional/client/BidirectionalClientLauncher.kt
@@ -2,6 +2,7 @@ package com.fResult.rsocket.bidirectional.client
 
 import com.fResult.rsocket.EncodingUtils
 import com.fResult.rsocket.FResultProperties
+import com.fResult.rsocket.bidirectional.GreetingResponse
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import org.springframework.boot.context.event.ApplicationReadyEvent
@@ -32,6 +33,11 @@ class BidirectionalClientLauncher(
       .map { id -> BidirectionalClient(encodingUtils, id.toString(), hostname, port) }
       .flatMap { client -> Flux.just(client).delayElements((1..30).random().seconds.toJavaDuration()) }
       .flatMap(BidirectionalClient::getGreetings)
-      .subscribe(log::info)
+      .subscribe(::logGreetingResponse)
+  }
+
+  private fun logGreetingResponse(greeting: GreetingResponse?): Unit {
+    greeting?.also { log.info(it.message) }
+      ?: log.warn("Received null GreetingResponse")
   }
 }

--- a/kotlin/08-rsocket/raw-rsocket/src/main/kotlin/com/fResult/rsocket/bidirectional/client/BidirectionalClientLauncher.kt
+++ b/kotlin/08-rsocket/raw-rsocket/src/main/kotlin/com/fResult/rsocket/bidirectional/client/BidirectionalClientLauncher.kt
@@ -1,0 +1,37 @@
+package com.fResult.rsocket.bidirectional.client
+
+import com.fResult.rsocket.EncodingUtils
+import com.fResult.rsocket.FResultProperties
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+import reactor.core.publisher.Flux
+import java.util.stream.IntStream
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toJavaDuration
+
+@Component
+class BidirectionalClientLauncher(
+  private val props: FResultProperties,
+  private val encodingUtils: EncodingUtils,
+) {
+  companion object {
+    val log: Logger = LogManager.getLogger(BidirectionalClientLauncher::class.java)
+  }
+
+  @EventListener(ApplicationReadyEvent::class)
+  fun onApplicationReady() {
+    val maxClients = (5..10).random()
+    val hostname = props.rsocket.hostname
+    val port = props.rsocket.port
+    log.info("Launching {} clients connecting to {}:{}", maxClients, hostname, port)
+
+    Flux.fromStream(IntStream.range(0, maxClients).boxed())
+      .map { id -> BidirectionalClient(encodingUtils, id.toString(), hostname, port) }
+      .flatMap { client -> Flux.just(client).delayElements((1..30).random().seconds.toJavaDuration()) }
+      .flatMap(BidirectionalClient::getGreetings)
+      .subscribe(log::info)
+  }
+}

--- a/kotlin/08-rsocket/raw-rsocket/src/main/kotlin/com/fResult/rsocket/bidirectional/client/BidirectionalClientLauncher.kt
+++ b/kotlin/08-rsocket/raw-rsocket/src/main/kotlin/com/fResult/rsocket/bidirectional/client/BidirectionalClientLauncher.kt
@@ -37,7 +37,7 @@ class BidirectionalClientLauncher(
   }
 
   private fun logGreetingResponse(greeting: GreetingResponse?): Unit {
-    greeting?.also { log.info(it.message) }
+    greeting?.apply { log.info(message) }
       ?: log.warn("Received null GreetingResponse")
   }
 }

--- a/kotlin/08-rsocket/raw-rsocket/src/main/kotlin/com/fResult/rsocket/bidirectional/client/BidirectionalClientLauncher.kt
+++ b/kotlin/08-rsocket/raw-rsocket/src/main/kotlin/com/fResult/rsocket/bidirectional/client/BidirectionalClientLauncher.kt
@@ -30,10 +30,18 @@ class BidirectionalClientLauncher(
     log.info("Launching {} clients connecting to {}:{}", maxClients, hostname, port)
 
     Flux.fromStream(IntStream.range(0, maxClients).boxed())
-      .map { id -> BidirectionalClient(encodingUtils, id.toString(), hostname, port) }
+      .map(buildBidirectionalClient(encodingUtils, hostname, port))
       .flatMap { client -> Flux.just(client).delayElements((1..30).random().seconds.toJavaDuration()) }
       .flatMap(BidirectionalClient::getGreetings)
       .subscribe(::logGreetingResponse)
+  }
+
+  private fun buildBidirectionalClient(
+    encodingUtils: EncodingUtils,
+    host: String,
+    port: Int
+  ): (Int) -> BidirectionalClient = { id ->
+    BidirectionalClient(encodingUtils, id.toString(), host, port)
   }
 
   private fun logGreetingResponse(greeting: GreetingResponse?): Unit {

--- a/kotlin/08-rsocket/raw-rsocket/src/main/kotlin/com/fResult/rsocket/bidirectional/client/BidirectionalClientLauncher.kt
+++ b/kotlin/08-rsocket/raw-rsocket/src/main/kotlin/com/fResult/rsocket/bidirectional/client/BidirectionalClientLauncher.kt
@@ -49,7 +49,7 @@ class BidirectionalClientLauncher(
     BidirectionalClient(encodingUtils, id.toString(), host, port)
   }
 
-  fun toDelayClient(client: BidirectionalClient): Flux<BidirectionalClient> =
+  private fun toDelayClient(client: BidirectionalClient): Flux<BidirectionalClient> =
     Flux.just(client).delayElements((1..30).random().seconds.toJavaDuration())
 
   private fun retryBackoffOnClosedChannel(init: RetryConfigBuilder.() -> Unit): RetryBackoffSpec {

--- a/kotlin/08-rsocket/raw-rsocket/src/main/kotlin/com/fResult/rsocket/bidirectional/service/BidirectionalApplication.kt
+++ b/kotlin/08-rsocket/raw-rsocket/src/main/kotlin/com/fResult/rsocket/bidirectional/service/BidirectionalApplication.kt
@@ -1,0 +1,13 @@
+package com.fResult.rsocket.bidirectional.service
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+@SpringBootApplication
+class BidirectionalApplication
+
+@Throws(InterruptedException::class)
+fun main(args: Array<String>) {
+  runApplication<BidirectionalApplication>(*args)
+  Thread.currentThread().join()
+}

--- a/kotlin/08-rsocket/raw-rsocket/src/main/kotlin/com/fResult/rsocket/bidirectional/service/BidirectionalService.kt
+++ b/kotlin/08-rsocket/raw-rsocket/src/main/kotlin/com/fResult/rsocket/bidirectional/service/BidirectionalService.kt
@@ -71,7 +71,7 @@ class BidirectionalService(
     { payload -> encodingUtils.decode(payload.dataUtf8, klass) }
 
   private fun isClientHealthStateStopped(chs: ClientHealthState) =
-    chs.state.equals(ClientHealthState.STOPPED, ignoreCase = true)
+    ClientHealthState.STOPPED.equals(chs.state, ignoreCase = true)
 
   private fun greetingResponseSupplierFrom(payload: Payload): () -> GreetingResponse = {
     val greetingRequest = payload.let(payloadToObject(GreetingRequest::class))

--- a/kotlin/08-rsocket/raw-rsocket/src/main/kotlin/com/fResult/rsocket/bidirectional/service/BidirectionalService.kt
+++ b/kotlin/08-rsocket/raw-rsocket/src/main/kotlin/com/fResult/rsocket/bidirectional/service/BidirectionalService.kt
@@ -1,0 +1,85 @@
+package com.fResult.rsocket.bidirectional.service
+
+import com.fResult.rsocket.EncodingUtils
+import com.fResult.rsocket.FResultProperties
+import com.fResult.rsocket.bidirectional.ClientHealthState
+import com.fResult.rsocket.bidirectional.GreetingRequest
+import com.fResult.rsocket.bidirectional.GreetingResponse
+import io.rsocket.ConnectionSetupPayload
+import io.rsocket.Payload
+import io.rsocket.RSocket
+import io.rsocket.core.RSocketServer
+import io.rsocket.transport.netty.server.CloseableChannel
+import io.rsocket.transport.netty.server.TcpServerTransport
+import io.rsocket.util.DefaultPayload
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import java.time.Instant
+import java.util.stream.Stream
+import kotlin.math.max
+import kotlin.reflect.KClass
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toJavaDuration
+
+@Component
+class BidirectionalService(
+  private val props: FResultProperties,
+  private val encodingUtils: EncodingUtils,
+) {
+  companion object {
+    val log: Logger = LogManager.getLogger(BidirectionalService::class.java)
+  }
+
+  @EventListener(ApplicationReadyEvent::class)
+  fun onApplicationReady() {
+    val serverTransport = TcpServerTransport.create(props.rsocket.hostname, props.rsocket.port)
+    val socketServer = RSocketServer.create(::socketAcceptor)
+
+    socketServer.bind(serverTransport).doOnNext(::logStartup).block()
+  }
+
+  private fun socketAcceptor(setup: ConnectionSetupPayload, sendingSocket: RSocket) =
+    Mono.just(createRequestStreamHandler(sendingSocket))
+
+  private fun createRequestStreamHandler(clientRSocket: RSocket): RSocket {
+    return object : RSocket {
+      override fun requestStream(payload: Payload): Flux<Payload> =
+        streamUntilClientStop(clientRSocket, payload)
+    }
+  }
+
+  private fun streamUntilClientStop(clientRSocket: RSocket, payload: Payload): Flux<Payload> {
+    val clientHealthStream = clientRSocket.requestStream(DefaultPayload.create(ByteArray(0)))
+      .map(::payloadToClientHealthState)
+      .filter(::isClientHealthStateStopped)
+
+    val replyPayloads = Flux.fromStream(Stream.generate(greetingResponseSupplierFrom(payload)))
+      .delayElements(max(3, (Math.random() * 10).toInt()).seconds.toJavaDuration())
+      .doFinally { signalType -> log.info("Finished.") }
+
+    return replyPayloads.takeUntilOther(clientHealthStream)
+      .map(encodingUtils::encode)
+      .map(DefaultPayload::create)
+  }
+
+  private fun payloadToClientHealthState(payload: Payload): ClientHealthState =
+    encodingUtils.decode(payload.dataUtf8, ClientHealthState::class)
+
+  private fun isClientHealthStateStopped(chs: ClientHealthState) =
+    chs.state.equals(ClientHealthState.STOPPED, ignoreCase = true)
+
+  private fun greetingResponseSupplierFrom(payload: Payload): () -> GreetingResponse = {
+    val greetingRequest = encodingUtils.decode(payload.dataUtf8, GreetingRequest::class)
+    val message = "Hello, ${greetingRequest.name} @ ${Instant.now()}"
+
+    GreetingResponse(message)
+  }
+
+  private fun logStartup(channel: CloseableChannel): Unit =
+    log.info("Server started on the address: {}", channel.address())
+}

--- a/kotlin/08-rsocket/raw-rsocket/src/main/kotlin/com/fResult/rsocket/fireAndForget/client/FireAndForgetClient.kt
+++ b/kotlin/08-rsocket/raw-rsocket/src/main/kotlin/com/fResult/rsocket/fireAndForget/client/FireAndForgetClient.kt
@@ -1,7 +1,6 @@
 package com.fResult.rsocket.fireAndForget.client
 
 import com.fResult.rsocket.FResultProperties
-import io.rsocket.Payload
 import io.rsocket.core.RSocketClient
 import io.rsocket.core.RSocketConnector
 import io.rsocket.transport.netty.client.TcpClientTransport


### PR DESCRIPTION
# Lesson 08: Raw RSocket sub-project (Bidirectional, Metadata)

## What’s in this batch of changes?

- **README tweaks**  
    - Added notes on Gradle Kotlin-DSL quirks (type-safe vs. string deps, afterEvaluate, plugin `apply(false)`)
- **Build updates**  
    - Pulled in `jackson-module-kotlin` so our data classes actually deserialize  
    - Added Netty’s macOS ARM DNS resolver to silence the native-lib warnings
- **EncodingUtils cleanup**  
    - Switched metadata reader to a proper `TypeReference<Map<String,Any>>`  
    - Hoisted duplicate exception‐handling into one helper  
    - Removed the extra `ObjectMapper` bean—only `EncodingUtils` now
- **Retry DSL**  
    - New tiny DSL under `dsl.retry`: `RetryConfig`, `RetryConfigBuilder`, and a `retryBackoffOnClosedChannel { … }` factory  
    - Client now does `.retryWhen(retryBackoffOnClosedChannel { maxAttempts = 5 })` with backoff + jitter + ClosedChannel filter
- **Bidirectional RSocket example**  
    - New raw-rsocket modules for server & client (DTOs, launcher, service)  
    - Client launcher refactored to named handlers (`onGreetingReceived`, `onGreetingError`, `onGreetingComplete`)  
    - Service now logs “Finished greeting to <clientId>.” so you know which client ended
- **Misc**  
    - Added Gradle `bootBidirectionalService` & `bootBidirectionalClient` tasks  
    - Cleaned up some unused imports in Fire-and-Forget example

Basically just personal clean-ups and a small retry DSL on top of the book’s starting code.
